### PR TITLE
Consent update with consentMode object instead of consent object

### DIFF
--- a/tutorials/4-consent-mode/src/public/partials/consent.eta
+++ b/tutorials/4-consent-mode/src/public/partials/consent.eta
@@ -59,7 +59,7 @@
       'analytics_storage': consent.analytics ? 'granted' : 'denied',
       'personalization': consent.preferences ? 'granted' : 'denied',
     };
-    gtag('consent', 'update', consent);  
+    gtag('consent', 'update', consentMode);  
     localStorage.setItem('consentMode', JSON.stringify(consentMode));
   }
   


### PR DESCRIPTION
Updating the dataLayer through `gtag` with the `consent` object will not trigger a consent update, instead use the `consentMode` object which holds the properties ga4 understands. In other words:

```javascript
// update consent with an object holding these properties...
  consentMode = {
    'functionality_storage': 'granted', // or 'denied'
    'security_storage': 'granted', // or 'denied'
    'ad_storage': 'granted', // or 'denied'
    'analytics_storage': 'granted', // or 'denied'
    'personalization': 'granted', // or 'denied'
  }

// instead of these...
  consent = {
    necessary: true, // or false,
    analytics: true, // or false,
    preferences: true, // or false,
    marketing: true // or false,
  }
```