### PR TITLE
refactored serveHttp to use serve and updated Eta to latest version

### DIFF
--- a/src/deno.lock
+++ b/src/deno.lock
@@ -1,49 +1,33 @@
 {
-  "version": "2",
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@std/assert@^0.225.1": "jsr:@std/assert@0.225.1",
+      "jsr:@std/cli": "jsr:@std/cli@0.224.1"
+    },
+    "jsr": {
+      "@std/assert@0.225.1": {
+        "integrity": "7342fa32a6d82c2c7c98ffea566baa9a892d04b22815b9fcf62cedeee5764f9c"
+      },
+      "@std/cli@0.224.1": {
+        "integrity": "f631d47fc9802541399d00a1f77ac62ac709e7465b6bc52547caa358c486b36e",
+        "dependencies": [
+          "jsr:@std/assert@^0.225.1"
+        ]
+      }
+    }
+  },
   "remote": {
-    "https://deno.land/std@0.207.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
-    "https://deno.land/std@0.207.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
-    "https://deno.land/std@0.207.0/cli/parse_args.ts": "9bea02050b3f302e706871ff87ecfa3ad82cc34249adbe0dcddfaac75bdb48ff",
-    "https://deno.land/std@0.207.0/flags/mod.ts": "567a34800a33e701942cb1726dd7e627a76e4681c33ce7346ac85cf90f691a8e",
-    "https://deno.land/std@0.66.0/_util/assert.ts": "e1f76e77c5ccb5a8e0dbbbe6cce3a56d2556c8cb5a9a8802fc9565af72462149",
-    "https://deno.land/std@0.66.0/fs/_util.ts": "68508c05d5a02678179a02beabf2b3eac5b16c5a9cbd1c272686d8101bb2679d",
-    "https://deno.land/std@0.66.0/fs/copy.ts": "b562e8f482cb8459bb011cbd769769bbdb4f6bc966effd277c06edbdbe41b72e",
-    "https://deno.land/std@0.66.0/fs/empty_dir.ts": "4d706eb01e5d08d862c673200d1978526e485368559fc7fb0f297add68f9cc43",
-    "https://deno.land/std@0.66.0/fs/ensure_dir.ts": "54cf0cfb16160857116d1bdff98214ad0189275fe2f089607fdc06c52ac79cc4",
-    "https://deno.land/std@0.66.0/fs/ensure_file.ts": "b70eccaee6f41ae226d399ad9c8ebc29beb5dd86fe179d30ab7e681976352baf",
-    "https://deno.land/std@0.66.0/fs/ensure_link.ts": "f647cea5c3b65f4a6618444546e9ca891d38f54f7fd4c718fb1fd575b4232213",
-    "https://deno.land/std@0.66.0/fs/ensure_symlink.ts": "d472af1507fb920db214f6816522ddc89eefd5800735243873053b2523882ec1",
-    "https://deno.land/std@0.66.0/fs/eol.ts": "4a0b2a612e0639b76d9c5fab0392e7bf1a158a7dab191ff7b7564870a1173812",
-    "https://deno.land/std@0.66.0/fs/exists.ts": "5429dce6587bfcdde06a7a2a1fd5ad932c17d74ca082e67934fa646cff1d2e57",
-    "https://deno.land/std@0.66.0/fs/expand_glob.ts": "07fa1edc468ac32779c709dd047f8067db90ac81db2d8bc4e92b08f5f83907e6",
-    "https://deno.land/std@0.66.0/fs/mod.ts": "88bb982130bb86df1cb350619fed4118c4cc439eeced6484330b7255e3a16568",
-    "https://deno.land/std@0.66.0/fs/move.ts": "020f56063c66288facbebc7d3c8dd3f309b0949fcaea49e463ccd5217fc82e2c",
-    "https://deno.land/std@0.66.0/fs/read_json.ts": "6922a9adc50cd2a7233298fd7b7ad9062d8602a55d4abb2b72d23ef0268b1306",
-    "https://deno.land/std@0.66.0/fs/walk.ts": "1715028b1646648b1239b9f93ff42beaf38f8e77424f8f9c2ffab9ee1594a54f",
-    "https://deno.land/std@0.66.0/fs/write_json.ts": "89a6231f51a6759dfff8f1f5534d030c2239c22fc9f3c0b3305d424f4f1d5604",
-    "https://deno.land/std@0.66.0/path/_constants.ts": "aba480c4a2c098b6374fdd5951fea13ecc8aaaf8b8aa4dae1871baa50243d676",
-    "https://deno.land/std@0.66.0/path/_interface.ts": "5876f91d35fd42624893a4aaddaee352144e1f46e719f1dde6511bab7c3c1029",
-    "https://deno.land/std@0.66.0/path/_util.ts": "f0fa012d40ae9b6acbef03908e534eb11e694de6470fb4d78ea4f38829e735ab",
-    "https://deno.land/std@0.66.0/path/common.ts": "e4ec66a7416d56f60331b66e27a8a4f08c7b1cf48e350271cb69754a01cf5c04",
-    "https://deno.land/std@0.66.0/path/glob.ts": "43cc45e8649a35a199c4106dfdf66206f46dfd8e2e626a746512c1a1376fde99",
-    "https://deno.land/std@0.66.0/path/mod.ts": "6de8885c2534757097818e302becd1cefcbc4c28ac022cc279e612ee04e8cfd1",
-    "https://deno.land/std@0.66.0/path/posix.ts": "40c387415fca91b3482214cf74880c415cda90b337bebd2c9d4b62d2097bc146",
-    "https://deno.land/std@0.66.0/path/separator.ts": "9dd15d46ff84a16e13554f56af7fee1f85f8d0f379efbbe60ac066a60561f036",
-    "https://deno.land/std@0.66.0/path/win32.ts": "9e200471f24fb560d22e74b238133cb75ebb57bead933de1cc5aefed4cda3346",
-    "https://deno.land/x/eta@v1.11.0/compile-string.ts": "3537fc3bf5173a0bc22eb326bd6905bba4dbd45a09f676c9c73cd07a71700fa8",
-    "https://deno.land/x/eta@v1.11.0/compile.ts": "264bd16f2ca0c38dc1404324147d3b36079f018af2880bf8840aec11e35331a1",
-    "https://deno.land/x/eta@v1.11.0/config.ts": "942f054e10b156e4a61c377f88cd9fa25c39a2797c862c26c5819b4d083f448b",
-    "https://deno.land/x/eta@v1.11.0/containers.ts": "98f50a2d8f42becc92664611772de03b28f7459d607da34be2a125dda8cc8288",
-    "https://deno.land/x/eta@v1.11.0/err.ts": "1f12ec5d6e25f8b75ecf19e93e61746b785f9b15026919ba1af18560a0d86405",
-    "https://deno.land/x/eta@v1.11.0/file-handlers.ts": "4093c590757625a1815352231e0883703fbd10e3b4cdd9573be1369c095f97ed",
-    "https://deno.land/x/eta@v1.11.0/file-helpers.ts": "1ae72ce2bb15def24916caf1b949083341d9551b19a1d012da73a972770748aa",
-    "https://deno.land/x/eta@v1.11.0/file-methods.ts": "bf2f3c0c088ecdddb3fc437c061a075acd05f517991778a4146aab8aadb159f3",
-    "https://deno.land/x/eta@v1.11.0/file-utils.ts": "7e19e23004389a2c2d4275d8ef7d5772461f984d475e68ea14e4f970c6c1f6f1",
-    "https://deno.land/x/eta@v1.11.0/mod.ts": "4e9c15c805179a1a2225dfd56ada1dad4e2d1fbb224a08da7e2358932f4f3301",
-    "https://deno.land/x/eta@v1.11.0/parse.ts": "43fd7e48f83706b528c294a8aa633438577d9e7e666a5fc9d979af943dbed624",
-    "https://deno.land/x/eta@v1.11.0/polyfills.ts": "c43398900fb5d71de3f85ea89f4b9eb695811402a4c254e91ffb0bd4f8a5d2af",
-    "https://deno.land/x/eta@v1.11.0/render.ts": "c4a4f7cdfffbbaa65d5a3c050d89dadf061e11dbb8e20cf43f08c555ae096f25",
-    "https://deno.land/x/eta@v1.11.0/storage.ts": "6b15a10a81c7a1189259c76e06a51302f4d8f8ee178c865457758841859e3351",
-    "https://deno.land/x/eta@v1.11.0/utils.ts": "f3ef645585afe6f4497e103fc98b30526fadc4d05965252c079145ee73ca9c13"
+    "https://deno.land/x/eta@v3.0.3/src/compile-string.ts": "e919c1a5e2cf460dbbd93047ab3548a630e5eb5c7fa019335c08e95b50e86cd7",
+    "https://deno.land/x/eta@v3.0.3/src/compile.ts": "146782227ddd5c423d07dedb2be40a2a5643c7429d9a3af5ac9a79c21bf7ae95",
+    "https://deno.land/x/eta@v3.0.3/src/config.ts": "7e2971ba3ec4b31b5f1ae0ea71957f0a2b868285192be77836d65ca27adb4f90",
+    "https://deno.land/x/eta@v3.0.3/src/core.ts": "53a9a10c8fc06ce88155a125ffb7db724afb7b4e16d6f646b20a29f27baa2cdf",
+    "https://deno.land/x/eta@v3.0.3/src/err.ts": "e9732b5f7fe729fed9d67868ff7d87ef1002d45d0a8a4e8f7fb1fa9ec2e2d50b",
+    "https://deno.land/x/eta@v3.0.3/src/file-handling.ts": "ac54a84c4e73f47629d69725b8557080caf4e03cf34413b4a2a3f3a10c0abb25",
+    "https://deno.land/x/eta@v3.0.3/src/index.ts": "fa1e18db556462293408c7a455b05b5253aae460c97811f88bb023cdc3f95f62",
+    "https://deno.land/x/eta@v3.0.3/src/parse.ts": "8cb25b4ccf58ea7f08fe9835f7eb8bf45917d6d743d28d1e25cadc9fc908cb32",
+    "https://deno.land/x/eta@v3.0.3/src/render.ts": "bfd57548d5fdae11c1c1683ff748783c1f85be3db3c24fcc80ce915692b004dd",
+    "https://deno.land/x/eta@v3.0.3/src/storage.ts": "c40bd31cdd6f1218c86f70067282709e2f2c7fa7eea67547be950e1ed5d4bd4c",
+    "https://deno.land/x/eta@v3.0.3/src/utils.ts": "1994c8d228195558fb6785fb00a97cf21a457df598a6ab1945170f7a4b7f00d9"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,46 @@
-import { configure, renderFile } from "https://deno.land/x/eta@v1.11.0/mod.ts";
-import { parse } from "https://deno.land/std@0.207.0/flags/mod.ts";
+import { Eta } from "https://deno.land/x/eta@v3.0.3/src/index.ts";
+import { parseArgs } from "jsr:@std/cli/parse-args";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 
-const viewPath = [
-  `${__dirname}/public`,
-  `${__dirname}/public/partials`,
-  `${__dirname}/public/layouts`,
-];
+const viewpath = Deno.cwd() + "/src/public/";
+const eta = new Eta({ views: viewpath, cache: true });
 
-configure({ views: viewPath });
-const flags = parse(Deno.args, {
-  string: [ "port" ],
-  default: { port: 80 },
+const flags = parseArgs(Deno.args, {
+  string: ["port"],
+  default: { port: "3000" },
 });
 
-const server = Deno.listen({ port: flags.port });
-
-console.log("File server running on http://localhost:" + flags.port + "/");
-
-for await (const conn of server) {
-  handleHttp(conn).catch(console.error);
-}
-
-async function handleHttp(conn: Deno.Conn) {
-  const httpConn = Deno.serveHttp(conn);
-  for await (const requestEvent of httpConn) {
-    const url = new URL(requestEvent.request.url);
-    let filepath = decodeURIComponent(url.pathname);
-    if (filepath === "/") {
-      filepath = "index.eta";
-    } else if (filepath.toLocaleLowerCase().indexOf(".") <= 0) {
-      filepath = `${filepath}.eta`;
-    }
-
-    let file;
-    let response;
-    try {
-      console.log(filepath);
-      if (filepath.indexOf(".eta") > 0) {
-        response = new Response(await renderFile(filepath, {}), {
-          headers: { "content-type": "text/html" },
-        });
-      } else {
-        file = await Deno.open(__dirname + "public" + filepath, {
-          read: true,
-        });
-        const readableStream = file.readable;
-        response = new Response(readableStream);
-      }
-    } catch (e) {
-      console.error(e);
-      response = new Response("404 Not Found", { status: 404 });
-      return;
-    }
-
-    await requestEvent.respondWith(response);
+async function handler(request: Request) {
+  const url = new URL(request.url);
+  let filepath = decodeURIComponent(url.pathname);
+  if (filepath === "/") {
+    filepath = "/index.eta";
+  } else if (filepath.toLocaleLowerCase().indexOf(".") <= 0) {
+    filepath = `${filepath}.eta`;
   }
+
+  let file;
+  let response;
+  try {
+    console.log(filepath);
+    if (filepath.indexOf(".eta") > 0) {
+      response = new Response(await eta.render(filepath, {}), {
+        headers: { "content-type": "text/html" },
+      });
+    } else {
+      file = await Deno.open(__dirname + "public" + filepath, {
+        read: true,
+      });
+      const readableStream = file.readable;
+      response = new Response(readableStream);
+    }
+  } catch (e) {
+    console.error(e);
+    response = new Response("404 Not Found", { status: 404 });
+  }
+
+  return response;
 }
+
+Deno.serve({ port: parseInt(flags.port) }, handler);

--- a/src/public/about.eta
+++ b/src/public/about.eta
@@ -1,11 +1,10 @@
-<% layout("layout", { title: "About - GA Tutorials" }) %>
-    
-<%~ includeFile("nav") %>
+<% layout("./layouts/layout", { title: "About - GA Tutorials" }) %>
+
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-3 pb-5">
     <h1 class="pt-4 pb-2">About the tutorial series</h1>
-    <a class="twitter-share-button" target="_blank"
-        href="https://twitter.com/intent/tweet?text=%23HelloAnalytics%20%23GA4TutorialSeries">
+    <a class="twitter-share-button" target="_blank" href="https://twitter.com/intent/tweet?text=%23HelloAnalytics%20%23GA4TutorialSeries">
         <span>Tweet</span></a>
     <div class="pt-4 content-width">
         <p>The Google Analytics 4 Tutorials series is a collection of videos created by the Google Analytics team to
@@ -14,19 +13,15 @@
             using advanced features like ecommerce and user ID.</p>
         <p>All the videos in the series can be found on the
             <a href="https://www.youtube.com/channel/UCJ5UyIAa5nEGksjcdp43Ixw" target="_blank">Google
-                Analytics YouTube channel</a>, in the <a
-                href="https://youtube.com/playlist?list=PLI5YfMzCfRtZ4bHJJDl_IJejxMwZFiBwz" target="_blank">Google
+                Analytics YouTube channel</a>, in the <a href="https://youtube.com/playlist?list=PLI5YfMzCfRtZ4bHJJDl_IJejxMwZFiBwz" target="_blank">Google
                 Analytics 4
                 Tutorial playlist</a>. In addition to the
-            videos, the code for this website and other helpful resources are available in the <a
-                href="https://github.com/googleanalytics" target="_blank">Google Analytics GitHub repository</a>.
+            videos, the code for this website and other helpful resources are available in the <a href="https://github.com/googleanalytics" target="_blank">Google Analytics GitHub repository</a>.
         </p>
         <p>For more information about Google Analytics, including new features and instructions,
             see the Google Analytics <a href="https://support.google.com/analytics" target="_blank">help
-                center</a> and <a href="https://developers.google.com/analytics/devguides/collection/ga4"
-                target="_blank">developer site</a>.</p>
+                center</a> and <a href="https://developers.google.com/analytics/devguides/collection/ga4" target="_blank">developer site</a>.</p>
     </div>
 </main>
 
-<%~ includeFile("footer.eta") %>
-    
+<%~ include("./partials/footer.eta") %>

--- a/src/public/index.eta
+++ b/src/public/index.eta
@@ -1,11 +1,10 @@
-<% layout("layout", { title: "Home | Google Analytics Tutorials" }) %>
+<% layout("./layouts/layout", { title: "Home | Google Analytics Tutorials" }) %>
 
-<%~ includeFile("nav") %>
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-3 pb-5">
     <h1 class="pt-4 pb-2">Hello Analytics!</h1>
-    <a class="twitter-share-button" target="_blank"
-        href="https://twitter.com/intent/tweet?text=%23HelloAnalytics%20%23GA4TutorialSeries">
+    <a class="twitter-share-button" target="_blank" href="https://twitter.com/intent/tweet?text=%23HelloAnalytics%20%23GA4TutorialSeries">
         <span>Tweet</span></a>
     <div class="pt-4 content-width">
         <p>Welcome to the Google Analytics 4 Tutorial series!</p>
@@ -20,6 +19,4 @@
     </div>
 </main>
 
-<%~ includeFile("footer") %>
-
-  
+<%~ include("./partials/footer") %>

--- a/src/public/layouts/layout.eta
+++ b/src/public/layouts/layout.eta
@@ -6,14 +6,16 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" type="image/x-icon" href="images/favicon.png">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <link rel="stylesheet" href="index.css">
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        
-        if(localStorage.getItem('consentMode') === null){
+
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+
+        if (localStorage.getItem('consentMode') === null) {
             gtag('consent', 'default', {
                 'ad_storage': 'denied',
                 'analytics_storage': 'denied',
@@ -25,37 +27,45 @@
             gtag('consent', 'default', JSON.parse(localStorage.getItem('consentMode')));
         }
 
-        if(localStorage.getItem('userId') != null) {
-            window.dataLayer.push({'user_id': localStorage.getItem('userId')});
+        if (localStorage.getItem('userId') != null) {
+            window.dataLayer.push({
+                'user_id': localStorage.getItem('userId')
+            });
         }
     </script>
     <!-- Google Tag Manager -->
-    <script>(function (w, d, s, l, i) {
-            w[l] = w[l] || []; w[l].push({
-                'gtm.start':
-                    new Date().getTime(), event: 'gtm.js'
-            }); var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-MHJNBK6');</script>
+    <script>
+        (function(w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({
+                'gtm.start': new Date().getTime(),
+                event: 'gtm.js'
+            });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src =
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-MHJNBK6');
+    </script>
     <!-- End Google Tag Manager -->
     <title><%= it.title %></title>
 </head>
 
 <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHJNBK6" height="0" width="0"
-            style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHJNBK6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    
+
     <%~ it.body %>
 
-    <%~ includeFile("debug")  %>
+    <%~ include("../partials/debug")  %>
 
-    <%~ includeFile("consent")  %>
+    <%~ include("../partials/consent")  %>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
-        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
 </body>
+
 </html>

--- a/src/public/login.eta
+++ b/src/public/login.eta
@@ -1,17 +1,16 @@
-<% layout("layout", { title: "Login - GA Tutorials" }) %>
-    
-<%~ includeFile("nav") %>
+<% layout("./layouts/layout", { title: "Login - GA Tutorials" }) %>
+
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-3">
     <h1>Simulate login to set User ID</h1>
     <form id="login-form">
         <div class="form-group">
             <label for="user-id">GA4 User ID</label>
-            <input type="text" class="form-control" id="user" name="user-id" aria-describedby="userIdHelp"
-                placeholder="Enter User ID">
+            <input type="text" class="form-control" id="user" name="user-id" aria-describedby="userIdHelp" placeholder="Enter User ID">
             <small id="userIdHelp" class="form-text text-muted">This form simply
-            sets your User ID so tagging will include it in events. To log out, submit
-            the form without a value.</small>
+                sets your User ID so tagging will include it in events. To log out, submit
+                the form without a value.</small>
         </div>
         <button type="submit" id="btn-login" class="btn btn-primary">Submit</button>
         <button type="button" id="gen-id" class="btn btn-info">Generate ID</button>
@@ -20,7 +19,6 @@
 </main>
 
 <script>
-  
     document.getElementById('btn-login').addEventListener('click', function() {
         loginUserId(document.getElementById('user').value);
     });
@@ -76,8 +74,6 @@
     }
 
     window.onload = () => document.getElementById('user').value = localStorage.getItem('userId');
-  
 </script>
 
-<%~ includeFile("footer.eta") %>
- 
+<%~ include("./partials/footer.eta") %>

--- a/src/public/newsletter.eta
+++ b/src/public/newsletter.eta
@@ -1,14 +1,13 @@
-<% layout("layout", { title: "Newsletter Signup - GA Tutorials" }) %>
-    
-<%~ includeFile("nav") %>
+<% layout("./layouts/layout", { title: "Newsletter Signup - GA Tutorials" }) %>
+
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-3">
     <h1>Signup for our Newsletter</h1>
     <form id="newsletter-form" action="/thank-you">
         <div class="form-group">
             <label for="email">Email address</label>
-            <input type="email" class="form-control" id="email" name="email" aria-describedby="emailHelp"
-                placeholder="Enter email">
+            <input type="email" class="form-control" id="email" name="email" aria-describedby="emailHelp" placeholder="Enter email">
             <small id="emailHelp" class="form-text text-muted">This form does not save your email. It is for the
                 demo.</small>
         </div>
@@ -16,5 +15,4 @@
     </form>
 </main>
 
-<%~ includeFile("footer.eta") %>
- 
+<%~ include("./partials/footer.eta") %>

--- a/src/public/profile.eta
+++ b/src/public/profile.eta
@@ -1,6 +1,6 @@
-<% layout("layout", { title: "Profile - GA Tutorials" }) %>
+<% layout("./layouts/layout", { title: "Profile - GA Tutorials" }) %>
 
-<%~ includeFile("nav") %>
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-3">
     <h1>Choose your role:</h1>
@@ -20,4 +20,4 @@
     </form>
 </main>
 
-<%~ includeFile("footer.eta") %>
+<%~ include("./partials/footer.eta") %>

--- a/src/public/thank-you.eta
+++ b/src/public/thank-you.eta
@@ -1,6 +1,6 @@
-<% layout("layout", { title: "Thank You! - GA Tutorials" }) %>
-    
-<%~ includeFile("nav") %>
+<% layout("./layouts/layout", { title: "Thank You! - GA Tutorials" }) %>
+
+<%~ include("./partials/nav") %>
 
 <main class="container-lg pt-4">
     <h1>Thank You for signing up!</h1>
@@ -8,4 +8,4 @@
         the <a href="/about">About</a> page.</p>
 </main>
 
-<%~ includeFile("footer.eta") %>
+<%~ include("./partials/footer.eta") %>


### PR DESCRIPTION
Deno is deprecating Deno.serverHttp in favor of Deno.serve. This required some refactoring as the signatures have changed. 

Eta was also out of date, so I updated the dependency and made the appropriate changes to the .eta files.